### PR TITLE
Update RNJWPlayer.podspec to use iOS SDK 4.6.1

### DIFF
--- a/ios/RNJWPlayer.podspec
+++ b/ios/RNJWPlayer.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "10.0"
   s.source       = { :git => "https://github.com/chaimPaneth/react-native-jw-media-player.git", :tag => "v#{s.version}" }
   s.source_files  = "RNJWPlayer/*.{h,m}"
-  s.dependency   'JWPlayerKit', '~> 4.6.0'
+  s.dependency   'JWPlayerKit', '~> 4.6.1'
   s.dependency   'google-cast-sdk', '~> 4.7.0'
   s.dependency   'React'
   # s.static_framework = true


### PR DESCRIPTION
iOS SDK 4.6.1 was released this morning. This should fix the pre-roll running over video.